### PR TITLE
[Example]RxSwift(DelegateProxy 적용) + MVVM + NaverMaps 연동 완료

### DIFF
--- a/ARNavigation/App/Common/DelegateProxy/RxCoreLocationDelegateProxy.swift
+++ b/ARNavigation/App/Common/DelegateProxy/RxCoreLocationDelegateProxy.swift
@@ -34,8 +34,12 @@ extension Reactive where Base: CLLocationManager {
     var didUpdateLocations: Observable<Result<NMGLatLng, GPSError>> {
         return delegateCLLocationManager.methodInvoked(#selector(CLLocationManagerDelegate.locationManager(_:didUpdateLocations:)))
             .map {
-                guard let curLocation = $0[1] as? [CLLocation] else {  return .failure(GPSError.coreLocationError) }
+                guard let curLocation = $0[1] as? [CLLocation] else {
+                    print("getCurrentLocation 실패")
+                    return .failure(GPSError.coreLocationError)
+                }
                 let coordinate = curLocation[0].coordinate
+                
                 return .success(NMGLatLng(lat: coordinate.latitude, lng: coordinate.longitude))
         }
     }

--- a/ARNavigation/App/Common/DelegateProxy/RxNaverMapsDelegateProxy.swift
+++ b/ARNavigation/App/Common/DelegateProxy/RxNaverMapsDelegateProxy.swift
@@ -10,6 +10,13 @@ import RxSwift
 import RxCocoa
 import NMapsMap
 
+func castOrThrow<T>(_ resultType: T.Type, _ object: Any) throws -> T {
+    guard let returnValue = object as? T else {
+        throw RxCocoaError.castingError(object: object, targetType: resultType)
+    }
+    return returnValue
+}
+
 class RxNMFMapViewDelegateProxy: DelegateProxy<NMFNaverMapView, NMFMapViewDelegate>, DelegateProxyType, NMFMapViewDelegate {
     static func registerKnownImplementations() {
         self.register { (naverMapView) -> RxNMFMapViewDelegateProxy in
@@ -24,6 +31,7 @@ class RxNMFMapViewDelegateProxy: DelegateProxy<NMFNaverMapView, NMFMapViewDelega
     static func setCurrentDelegate(_ delegate: NMFMapViewDelegate?, to object: NMFNaverMapView) {
         object.delegate = delegate
     }
+    
 }
 
 extension Reactive where Base: NMFNaverMapView {
@@ -32,18 +40,20 @@ extension Reactive where Base: NMFNaverMapView {
         return RxNMFMapViewDelegateProxy.proxy(for: self.base)
     }
     // map 터치시 좌표 봔환 콜백
-    var didTapMapView: Observable<NMGLatLng> {
-        return delegateNMFMapView.methodInvoked(#selector(NMFMapViewDelegate.didTapMapView(_:latLng:)))
-            .map {
-                return ($0[1] as? NMGLatLng ?? NMGLatLng())
-        }
+    var didTapMapView: ControlEvent<NMGLatLng> {
+        let source: Observable<NMGLatLng> = delegateNMFMapView
+            .methodInvoked(#selector(NMFMapViewDelegate.didTapMapView(_:latLng:)))
+            .map { try castOrThrow(NMGLatLng.self, $0[1]) }
+        return ControlEvent(events: source)
     }
-//    // map symbol 터치시 해당 심볼 정보 반환 콜백
-//    var didTapSymbol: ControlEvent<NMFSymbol> {
-//        let source : Observable<NMFSymbol> = delegateNMFMapView.methodInvoked(#selector(NMFMapViewDelegate.mapView(_:didTap:)))
-//        .map(<#T##transform: ([Any]) throws -> Result##([Any]) throws -> Result#>)
-//    }
-//    
+    // map symbol 터치시 해당 심볼 정보 반환 콜백
+    var didTapSymbol: ControlEvent<NMFSymbol> {
+        let source : Observable<NMFSymbol> = delegateNMFMapView
+            .methodInvoked(#selector(NMFMapViewDelegate.mapView(_:didTap:)))
+            .map { try castOrThrow(NMFSymbol.self, $0[1]) }
+        return ControlEvent(events: source)
+    }
+    
     var regionDidChangeAnimated: Observable<Bool> {
         return delegateNMFMapView.methodInvoked(#selector(NMFMapViewDelegate.mapView(_:regionDidChangeAnimated:byReason:)))
             .map {
@@ -52,3 +62,5 @@ extension Reactive where Base: NMFNaverMapView {
     }
     
 }
+
+

--- a/ARNavigation/App/Model/Location/LocationManager.swift
+++ b/ARNavigation/App/Model/Location/LocationManager.swift
@@ -6,8 +6,9 @@
 //  Copyright © 2020 youngjun goo. All rights reserved.
 //
 
-import Foundation
-import CoreLocation
+import RxSwift
+import RxCocoa
+import NMapsMap
 
 protocol LocationManager: class {
     
@@ -24,5 +25,8 @@ protocol LocationManager: class {
     func startUpdatingLocation()
     
     func stopUpdatingLocation()
+    
+    // location이 없데이트 되면 호출될 메서드
+    func didUpdateLocations() -> Observable<Result<NMGLatLng, GPSError>>
     
 }

--- a/ARNavigation/App/Model/Location/LocationManagerImpl.swift
+++ b/ARNavigation/App/Model/Location/LocationManagerImpl.swift
@@ -6,8 +6,10 @@
 //  Copyright © 2020 youngjun goo. All rights reserved.
 //
 
-import Foundation
+import RxSwift
+import RxCocoa
 import NMapsMap
+
 
 class LocationManagerImpl: NSObject {
     
@@ -67,11 +69,13 @@ extension LocationManagerImpl: LocationManager {
         locationManager.stopUpdatingLocation()
     }
     
+    func didUpdateLocations() -> Observable<Result<NMGLatLng, GPSError>> {
+        return locationManager.rx.didUpdateLocations
+    }
+    
 }
 
 
 extension LocationManagerImpl: CLLocationManagerDelegate {
-    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        
-    }
+
 }

--- a/ARNavigation/App/Presentation/NMView/Main/NMModel.swift
+++ b/ARNavigation/App/Presentation/NMView/Main/NMModel.swift
@@ -12,13 +12,22 @@ import RxCocoa
 import RxSwift
 
 struct NMModel {
-    let locationManager: CLLocationManager
+    let locationManager: LocationManager
     
-    init(locationManager: CLLocationManager = CLLocationManager()) {
+    init(locationManager: LocationManager = LocationManagerImpl()) {
+        print("Model Init")
         self.locationManager = locationManager
+        print(self.locationManager)
+        locationManager.requestAuthorization()
+        locationManager.startUpdatingLocation()
     }
     
     func getCurrentLocation() -> Observable<Result<NMGLatLng, GPSError>> {
-        return locationManager.rx.didUpdateLocations
+        print("Model getCurrentLocation")
+        return locationManager.didUpdateLocations()
+    }
+    
+    func parseData(value: NMGLatLng) -> NMGLatLng? {
+        return NMGLatLng(lat: value.lat, lng: value.lng)
     }
 }

--- a/ARNavigation/App/Presentation/NMView/Main/NMViewController.swift
+++ b/ARNavigation/App/Presentation/NMView/Main/NMViewController.swift
@@ -12,23 +12,19 @@ import RxSwift
 import RxCocoa
 
 class NMViewController: UIViewController {
+    var disposeBag = DisposeBag()
     
     @IBOutlet weak var naverMapView: NMFNaverMapView!
     @IBOutlet weak var navigationButton: UIButton!
     @IBOutlet weak var latLabel: UILabel!
     @IBOutlet weak var lngLabel: UILabel!
     @IBOutlet weak var symbolInfoView: UIView!
+    
     let viewModel = NMViewModel()
-    let locationManager = CLLocationManager()
-    let disposeBag = DisposeBag()
     
     override func viewDidLoad() {
         super.viewDidLoad()
         setUpNaverMapView()
-        naverMapView.delegate = self
-        locationManager.requestWhenInUseAuthorization()
-        locationManager.startUpdatingLocation()
-        
         bind()
     }
     
@@ -43,18 +39,19 @@ class NMViewController: UIViewController {
         naverMapView.showLocationButton = true
         naverMapView.showIndoorLevelPicker = true
     }
-
+    
     
     func bind() {
+        self.disposeBag = DisposeBag()
         // GPS 수신 동의 체크
-        checkGPSAuthorization()
+        // checkGPSAuthorization()
         
-//        naverMapView.rx.didTapSymbol
-//            .asObservable()
-//            .subscribe(onNext : {
-//                print($0)
-//            })
-//            .disposed(by: disposeBag)
+        naverMapView.rx.didTapSymbol
+            .asObservable()
+            .subscribe(onNext : {
+                print($0)
+            })
+            .disposed(by: disposeBag)
         
         naverMapView.rx.didTapMapView
             .asObservable()
@@ -70,45 +67,45 @@ class NMViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
-//        locationManager.rx.didUpdateLocations
-//            .asObservable()
-//            .map {
-//                return "경도 : \($0.lat)"
-//        }
-//        .bind(to: latLabel.rx.text)
-//        .disposed(by: disposeBag)
-//        
-//        locationManager.rx.didUpdateLocations
-//            .asObservable()
-//            .map {
-//                return "경도 : \($0.lng)"
-//        }
-//        .bind(to: lngLabel.rx.text)
-//        .disposed(by: disposeBag)
+        //        locationManager.rx.didUpdateLocations
+        //            .asObservable()
+        //            .map {
+        //                return "경도 : \($0.lat)"
+        //        }
+        //        .bind(to: latLabel.rx.text)
+        //        .disposed(by: disposeBag)
+        //
+        //        locationManager.rx.didUpdateLocations
+        //            .asObservable()
+        //            .map {
+        //                return "경도 : \($0.lng)"
+        //        }
+        //        .bind(to: lngLabel.rx.text)
+        //        .disposed(by: disposeBag)
         
-        viewModel.locationChanged.asObservable().map {
-            return "경도: \($0!.lng)"
-        }.bind(to: lngLabel.rx.text)
-        .disposed(by: disposeBag)
+        
+        viewModel.locationData
+            .emit(to: self.rx.setData)
+            .disposed(by: disposeBag)
         
     }
     
-    private func checkGPSAuthorization() {
-        locationManager.rx.didChangeAuthorization
-        .asObservable()
-            .subscribe(onNext: {
-                print($0)
-            })
-        .disposed(by: disposeBag)
-    }
+    //    private func checkGPSAuthorization() {
+    //        locationManager.rx.didChangeAuthorization
+    //            .asObservable()
+    //            .subscribe(onNext: {
+    //                print($0)
+    //            })
+    //            .disposed(by: disposeBag)
+    //    }
 }
 
-extension NMViewController: NMFMapViewDelegate {
-    func mapView(_ mapView: NMFMapView, didTap symbol: NMFSymbol) -> Bool {
-        print(symbol)
-        return true
+extension Reactive where Base: NMViewController {
+    var setData: Binder<NMGLatLng> {
+        return Binder(base) { base, data in
+            print(data)
+            base.latLabel.text = "경도: \(data.lat)"
+            base.lngLabel.text = "위도: \(data.lng)"
+        }
     }
-    
-    
-    
 }


### PR DESCRIPTION
기본적인 MVVM의 구조 초기 완성

- CLLocationManagerDelegate Proxy: didUpdateLocation 콜백 메서드를 프록시로 설정 -> rx와 연동
- Model: CLLocationManager를 init, CLLocationManager에 관련된 값 설정
- ViewModel: Model을 init, 디바이스 위치가 변경 될때마다 즉 Model의 LocationManager의 didUpdateLocations 함수가 호출을 구독하다가 호출 되는 순간 View(UILabel) 업데이트
- View/ViewController: ViewModel과 View의 UI를 bind 

